### PR TITLE
Introduce dotenv

### DIFF
--- a/components/BaseScript.vue
+++ b/components/BaseScript.vue
@@ -32,10 +32,10 @@ import BaseSegment from '@/components/BaseSegment.vue'
 
 Amplify.configure({
   "aws_project_region": "ap-northeast-1",
-  "aws_appsync_graphqlEndpoint": process.env.AWS_APPSYNC_GRAPHQLENDPOINT,
+  "aws_appsync_graphqlEndpoint": process.env.APPSYNC_GRAPHQLENDPOINT,
   "aws_appsync_region": "ap-northeast-1",
   "aws_appsync_authenticationType": "API_KEY",
-  "aws_appsync_apiKey": process.env.AWS_APPSYNC_APIKEY
+  "aws_appsync_apiKey": process.env.APPSYNC_APIKEY
 })
 
 type Segment = {

--- a/components/BaseScript.vue
+++ b/components/BaseScript.vue
@@ -20,7 +20,7 @@
 import { Vue, Component, Prop, Emit } from 'vue-property-decorator'
 
 import Amplify, { API, graphqlOperation } from 'aws-amplify'
-import awsconfig from '@/src/aws-exports.js'
+// import awsconfig from '@/src/aws-exports.js'
 
 import * as queries from '@/src/graphql/queries.ts'
 import * as mutations from '@/src/graphql/mutations.ts'
@@ -30,7 +30,13 @@ import { segmentStore } from '~/store'
 import Response from '@/assets/asrOutput.json'
 import BaseSegment from '@/components/BaseSegment.vue'
 
-Amplify.configure(awsconfig)
+Amplify.configure({
+  "aws_project_region": "ap-northeast-1",
+  "aws_appsync_graphqlEndpoint": process.env.AWS_APPSYNC_GRAPHQLENDPOINT,
+  "aws_appsync_region": "ap-northeast-1",
+  "aws_appsync_authenticationType": "API_KEY",
+  "aws_appsync_apiKey": process.env.AWS_APPSYNC_APIKEY
+})
 
 type Segment = {
   speaker: string


### PR DESCRIPTION
aws-export.js が無くてビルド通らないので、隠すべきものは環境変数化して使うのをやめた